### PR TITLE
Fix `#@no-save-missing`

### DIFF
--- a/wwiser/names/wnamedumper.py
+++ b/wwiser/names/wnamedumper.py
@@ -202,7 +202,8 @@ class Namedumper(object):
             for subline in sublines:
                 lines.append(subline)
 
-        lines += missing_lines
+        if missing_lines:
+            lines += missing_lines
 
 
     def _include_missing(self, hashtype, bank, header=False):


### PR DESCRIPTION
Currently if you use `#@no-save-missing` option in `wwnames.txt` it will fail with
```py
Traceback (most recent call last):
  File "wwiser/wwiser.py", line 48, in <module>
    main()
  File "wwiser/wwiser.py", line 15, in main
    wcli.Cli().start()
  File "wwiser/wwiser/wcli.py", line 182, in start
    self._run(args)
  File "wwiser/wwiser/wcli.py", line 260, in _run
    self._execute(args, filenames)
  File "wwiser/wwiser/wcli.py", line 380, in _execute
    names.save_lst(basename=dump_name)
  File "wwiser/wwiser/names/wnames.py", line 863, in save_lst
    dumper.save_lst(basename, path)
  File "wwiser/wwiser/names/wnamedumper.py", line 52, in save_lst
    lines = self.get_lines()
            ^^^^^^^^^^^^^^^^
  File "wwiser/wwiser/names/wnamedumper.py", line 87, in get_lines
    lines = self._include_classify(rows)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "wwiser/wwiser/names/wnamedumper.py", line 162, in _include_classify
    self._include_classify_lines(lines, hashtypes_lines, hashtype, bankkey)
  File "wwiser/wwiser/names/wnamedumper.py", line 205, in _include_classify_lines
    lines += missing_lines
TypeError: 'NoneType' object is not iterable
```

This PR fixes that.
