### PR TITLE
Fallback to cli if tkinker isn't available

### DIFF
--- a/wwiser.py
+++ b/wwiser.py
@@ -5,7 +5,6 @@
 
 import sys
 from wwiser import wcli
-from wwiser import wgui
 
 _PROFILE = False
 
@@ -14,8 +13,12 @@ def main():
     if len(sys.argv) > 1:
         wcli.Cli().start()
     else:
-        wgui.Gui().start()
+        try:
+            from wwiser import wgui
 
+            wgui.Gui().start()
+        except ModuleNotFoundError:
+            wcli.Cli().start()
 
 def profile_simple():
     try:


### PR DESCRIPTION
Handle running when tkinter isn't available even if it's not needed

When running with >1 argument on a system without tkinter available, Python gives:
```
Traceback (most recent call last):
  File "/Users/pc/wwiser/wwiser.py", line 8, in <module>
    from wwiser import wgui
  File "/Users/pc/wwiser/wwiser/wgui.py", line 2, in <module>
    import tkinter as tk
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/tkinter/__init__.py", line 38, in <module>
    import _tkinter # If this fails your Python may not be configured for Tk
    ^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named '_tkinter'
```